### PR TITLE
Add ability to fetch for Salesforce Object meta data to ForceAPI

### DIFF
--- a/src/main/java/com/springml/salesforce/wave/api/ForceAPI.java
+++ b/src/main/java/com/springml/salesforce/wave/api/ForceAPI.java
@@ -1,8 +1,12 @@
 package com.springml.salesforce.wave.api;
 
-import com.springml.salesforce.wave.model.*;
 
-import java.util.List;
+import com.springml.salesforce.wave.model.AddTaskRequest;
+import com.springml.salesforce.wave.model.AddTaskResponse;
+import com.springml.salesforce.wave.model.DescribeSObjectResult;
+import com.springml.salesforce.wave.model.ForceResponse;
+import com.springml.salesforce.wave.model.QueryResult;
+import com.springml.salesforce.wave.model.SOQLResult;
 
 /**
  * JAVA client for Salesforce REST API calls

--- a/src/main/java/com/springml/salesforce/wave/api/ForceAPI.java
+++ b/src/main/java/com/springml/salesforce/wave/api/ForceAPI.java
@@ -1,6 +1,5 @@
 package com.springml.salesforce.wave.api;
 
-
 import com.springml.salesforce.wave.model.AddTaskRequest;
 import com.springml.salesforce.wave.model.AddTaskResponse;
 import com.springml.salesforce.wave.model.DescribeSObjectResult;

--- a/src/main/java/com/springml/salesforce/wave/api/ForceAPI.java
+++ b/src/main/java/com/springml/salesforce/wave/api/ForceAPI.java
@@ -1,10 +1,8 @@
 package com.springml.salesforce.wave.api;
 
-import com.springml.salesforce.wave.model.AddTaskRequest;
-import com.springml.salesforce.wave.model.AddTaskResponse;
-import com.springml.salesforce.wave.model.ForceResponse;
-import com.springml.salesforce.wave.model.QueryResult;
-import com.springml.salesforce.wave.model.SOQLResult;
+import com.springml.salesforce.wave.model.*;
+
+import java.util.List;
 
 /**
  * JAVA client for Salesforce REST API calls
@@ -47,4 +45,12 @@ public interface ForceAPI {
 //    public InsertObjectsResponse insertObjects(String object, List<String> objects) throws Exception;
 
     public String getSFEndpoint() throws Exception;
+
+    /**
+     * Returns list of the salesforce object column names
+     * @param object Name of the salesforce object
+     * @return
+     * @throws Exception
+     */
+    public DescribeSObjectResult describeSalesforceObject(String object) throws Exception;
 }

--- a/src/main/java/com/springml/salesforce/wave/impl/ForceAPIImpl.java
+++ b/src/main/java/com/springml/salesforce/wave/impl/ForceAPIImpl.java
@@ -4,14 +4,12 @@ import static com.springml.salesforce.wave.util.WaveAPIConstants.*;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
+import com.springml.salesforce.wave.model.*;
 import org.apache.log4j.Logger;
 
 import com.springml.salesforce.wave.api.ForceAPI;
-import com.springml.salesforce.wave.model.AddTaskRequest;
-import com.springml.salesforce.wave.model.AddTaskResponse;
-import com.springml.salesforce.wave.model.ForceResponse;
-import com.springml.salesforce.wave.model.SOQLResult;
 import com.springml.salesforce.wave.util.SFConfig;
 
 /**
@@ -93,6 +91,23 @@ public class ForceAPIImpl extends AbstractAPIImpl implements ForceAPI {
                 null, null, null).toString();
     }
 
+    public DescribeSObjectResult describeSalesforceObject(String object) throws Exception {
+        SFConfig sfConfig = getSfConfig();
+        String objDescribePath = getSalesforceObjectDescribePath(sfConfig, object);
+        URI objDescribeURI = sfConfig.getRequestURI(
+                sfConfig.getPartnerConnection(), objDescribePath);
+
+        String responseStr = getHttpHelper().get(objDescribeURI, sfConfig.getSessionId());
+        DescribeSObjectResult response = null;
+        try {
+            response = getObjectMapper().readValue(responseStr.getBytes(), DescribeSObjectResult.class);
+        } catch (IOException e) {
+            response = new DescribeSObjectResult();
+            response.setError(responseStr);
+        }
+        return response;
+    }
+
     private String getInsertPath(SFConfig sfConfig, String object) {
         StringBuilder objPath = new StringBuilder();
         objPath.append(SERVICE_PATH);
@@ -149,6 +164,14 @@ public class ForceAPIImpl extends AbstractAPIImpl implements ForceAPI {
         queryPath.append(PATH_QUERY);
 
         return queryPath.toString();
+    }
+
+    private String getSalesforceObjectDescribePath(SFConfig sfConfig, String object) {
+        StringBuilder objDescribePath = new StringBuilder();
+        objDescribePath.append(getInsertPath(sfConfig, object));
+        objDescribePath.append("/describe");
+
+        return objDescribePath.toString();
     }
 
 }

--- a/src/main/java/com/springml/salesforce/wave/impl/ForceAPIImpl.java
+++ b/src/main/java/com/springml/salesforce/wave/impl/ForceAPIImpl.java
@@ -4,12 +4,15 @@ import static com.springml.salesforce.wave.util.WaveAPIConstants.*;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.List;
 
-import com.springml.salesforce.wave.model.*;
 import org.apache.log4j.Logger;
 
 import com.springml.salesforce.wave.api.ForceAPI;
+import com.springml.salesforce.wave.model.AddTaskRequest;
+import com.springml.salesforce.wave.model.AddTaskResponse;
+import com.springml.salesforce.wave.model.DescribeSObjectResult;
+import com.springml.salesforce.wave.model.ForceResponse;
+import com.springml.salesforce.wave.model.SOQLResult;
 import com.springml.salesforce.wave.util.SFConfig;
 
 /**

--- a/src/main/java/com/springml/salesforce/wave/model/DescribeSObjectResult.java
+++ b/src/main/java/com/springml/salesforce/wave/model/DescribeSObjectResult.java
@@ -1,0 +1,149 @@
+package com.springml.salesforce.wave.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DescribeSObjectResult implements Serializable {
+
+    private static final long serialVersionUID = 1739841107381849160L;
+
+    private boolean createable;
+    private boolean custom;
+    private boolean deletable;
+    private List<Field> fields;
+    private String name;
+    private boolean queryable;
+    private boolean replicateable;
+    private boolean retrieveable;
+    private boolean searchable;
+    private boolean undeletable;
+    private boolean updateable;
+    private String urlDetail;
+    private String urlEdit;
+    private String urlNew;
+
+    private String error;
+
+    public boolean isCreateable() {
+        return createable;
+    }
+
+    public void setCreateable(boolean createable) {
+        this.createable = createable;
+    }
+
+    public boolean isCustom() {
+        return custom;
+    }
+
+    public void setCustom(boolean custom) {
+        this.custom = custom;
+    }
+
+    public boolean isDeletable() {
+        return deletable;
+    }
+
+    public void setDeletable(boolean deletable) {
+        this.deletable = deletable;
+    }
+
+    public List<Field> getFields() {
+        return fields;
+    }
+
+    public void setFields(List<Field> fields) {
+        this.fields = fields;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isQueryable() {
+        return queryable;
+    }
+
+    public void setQueryable(boolean queryable) {
+        this.queryable = queryable;
+    }
+
+    public boolean isReplicateable() {
+        return replicateable;
+    }
+
+    public void setReplicateable(boolean replicateable) {
+        this.replicateable = replicateable;
+    }
+
+    public boolean isRetrieveable() {
+        return retrieveable;
+    }
+
+    public void setRetrieveable(boolean retrieveable) {
+        this.retrieveable = retrieveable;
+    }
+
+    public boolean isSearchable() {
+        return searchable;
+    }
+
+    public void setSearchable(boolean searchable) {
+        this.searchable = searchable;
+    }
+
+    public boolean isUndeletable() {
+        return undeletable;
+    }
+
+    public void setUndeletable(boolean undeletable) {
+        this.undeletable = undeletable;
+    }
+
+    public boolean isUpdateable() {
+        return updateable;
+    }
+
+    public void setUpdateable(boolean updateable) {
+        this.updateable = updateable;
+    }
+
+    public String getUrlDetail() {
+        return urlDetail;
+    }
+
+    public void setUrlDetail(String urlDetail) {
+        this.urlDetail = urlDetail;
+    }
+
+    public String getUrlEdit() {
+        return urlEdit;
+    }
+
+    public void setUrlEdit(String urlEdit) {
+        this.urlEdit = urlEdit;
+    }
+
+    public String getUrlNew() {
+        return urlNew;
+    }
+
+    public void setUrlNew(String urlNew) {
+        this.urlNew = urlNew;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/src/main/java/com/springml/salesforce/wave/model/Field.java
+++ b/src/main/java/com/springml/salesforce/wave/model/Field.java
@@ -1,0 +1,102 @@
+package com.springml.salesforce.wave.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Field implements Serializable {
+
+    private static final long serialVersionUID = 1739841109381849160L;
+
+    private String name;
+    private int length;
+    private String label;
+    private boolean filterable;
+    private boolean nameField;
+    private boolean nillable;
+    private boolean unique;
+    private boolean updateable;
+    private boolean custom;
+    private boolean createable;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public void setLength(int length) {
+        this.length = length;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public boolean isFilterable() {
+        return filterable;
+    }
+
+    public void setFilterable(boolean filterable) {
+        this.filterable = filterable;
+    }
+
+    public boolean isNameField() {
+        return nameField;
+    }
+
+    public void setNameField(boolean nameField) {
+        this.nameField = nameField;
+    }
+
+    public boolean isNillable() {
+        return nillable;
+    }
+
+    public void setNillable(boolean nillable) {
+        this.nillable = nillable;
+    }
+
+    public boolean isUnique() {
+        return unique;
+    }
+
+    public void setUnique(boolean unique) {
+        this.unique = unique;
+    }
+
+    public boolean isUpdateable() {
+        return updateable;
+    }
+
+    public void setUpdateable(boolean updateable) {
+        this.updateable = updateable;
+    }
+
+    public boolean isCustom() {
+        return custom;
+    }
+
+    public void setCustom(boolean custom) {
+        this.custom = custom;
+    }
+
+    public boolean isCreateable() {
+        return createable;
+    }
+
+    public void setCreateable(boolean createable) {
+        this.createable = createable;
+    }
+}

--- a/src/test/java/com/springml/salesforce/wave/api/ForceAPITest.java
+++ b/src/test/java/com/springml/salesforce/wave/api/ForceAPITest.java
@@ -10,12 +10,16 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import com.springml.salesforce.wave.model.*;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import com.springml.salesforce.wave.impl.ForceAPIImpl;
+import com.springml.salesforce.wave.model.AddTaskRequest;
+import com.springml.salesforce.wave.model.AddTaskResponse;
+import com.springml.salesforce.wave.model.DescribeSObjectResult;
+import com.springml.salesforce.wave.model.ForceResponse;
+import com.springml.salesforce.wave.model.SOQLResult;
 import com.springml.salesforce.wave.util.HTTPHelper;
 
 public class ForceAPITest extends BaseAPITest {


### PR DESCRIPTION
Reference: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_describe.htm

Exposes endpoint that describes the individual metadata at all levels for a specified Salesforce object.