### PR TITLE
Allow BulkAPI Client to include custom headers

### DIFF
--- a/src/main/java/com/springml/salesforce/wave/api/BulkAPI.java
+++ b/src/main/java/com/springml/salesforce/wave/api/BulkAPI.java
@@ -3,6 +3,8 @@ package com.springml.salesforce.wave.api;
 import com.springml.salesforce.wave.model.BatchInfo;
 import com.springml.salesforce.wave.model.BatchInfoList;
 import com.springml.salesforce.wave.model.JobInfo;
+import org.apache.http.Header;
+import java.util.List;
 
 /**
  * Java client for Salesforce Bulk API
@@ -35,6 +37,16 @@ public interface BulkAPI {
      * @throws Exception
      */
     public JobInfo createJob(JobInfo jobInfo) throws Exception;
+
+    /**
+     * Create a new Bulk Job
+     * https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_quickstart_create_job.htm
+     * @param jobInfo with details of the Job to be created
+     * @param customHeaders Custom headers for job. These headers will be appended to default headers.
+     * @return {@link JobInfo}
+     * @throws Exception
+     */
+    public JobInfo createJob(JobInfo jobInfo, List<Header> customHeaders) throws Exception;
 
     /**
      * Add a batch to an existing Job

--- a/src/main/java/com/springml/salesforce/wave/impl/BulkAPIImpl.java
+++ b/src/main/java/com/springml/salesforce/wave/impl/BulkAPIImpl.java
@@ -3,10 +3,12 @@ package com.springml.salesforce.wave.impl;
 import static com.springml.salesforce.wave.util.WaveAPIConstants.*;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
 import org.apache.log4j.Logger;
 
 import com.sforce.soap.partner.PartnerConnection;
@@ -38,11 +40,15 @@ public class BulkAPIImpl extends AbstractAPIImpl implements BulkAPI {
     }
 
     public JobInfo createJob(JobInfo jobInfo) throws Exception {
+        return createJob(jobInfo, new ArrayList<Header>());
+    }
+
+    public JobInfo createJob(JobInfo jobInfo, List<Header> customHeaders) throws Exception {
         PartnerConnection connection = getSfConfig().getPartnerConnection();
         URI requestURI = getSfConfig().getRequestURI(connection, getJobPath());
 
         String response = getHttpHelper().post(requestURI, getSfConfig().getSessionId(),
-                getObjectMapper().writeValueAsString(jobInfo), true);
+                getObjectMapper().writeValueAsString(jobInfo), true, customHeaders);
         LOG.debug("Response from Salesforce Server " + response);
 
         JobInfo respJobInfo = getObjectMapper().readValue(response.getBytes(), JobInfo.class);

--- a/src/main/java/com/springml/salesforce/wave/util/HTTPHelper.java
+++ b/src/main/java/com/springml/salesforce/wave/util/HTTPHelper.java
@@ -4,8 +4,11 @@ import static com.springml.salesforce.wave.util.WaveAPIConstants.*;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
@@ -32,7 +35,15 @@ public class HTTPHelper {
         return post(uri, sessionId, request, CONTENT_TYPE_APPLICATION_JSON, isBulk);
     }
 
+    public String post(URI uri, String sessionId, String request, boolean isBulk, List<Header> customHeaders) throws Exception {
+        return post(uri, sessionId, request, CONTENT_TYPE_APPLICATION_JSON, isBulk, customHeaders);
+    }
+
     public String post(URI uri, String sessionId, String request, String contentType, boolean isBulk) throws Exception {
+        return post(uri, sessionId, request, contentType, isBulk, new ArrayList<Header>());
+    }
+
+    public String post(URI uri, String sessionId, String request, String contentType, boolean isBulk, List<Header> customHeaders) throws Exception {
         LOG.info("Executing POST request on " + uri);
         LOG.debug("Sending request " + request);
         LOG.debug("Content-Type " + contentType);
@@ -48,6 +59,11 @@ public class HTTPHelper {
         HttpPost httpPost = new HttpPost(uri);
         httpPost.setEntity(entity);
         httpPost.setConfig(getRequestConfig());
+
+        for (Header customHeader : customHeaders) {
+            httpPost.addHeader(customHeader);
+        }
+
         if (isBulk) {
             httpPost.addHeader(HEADER_X_SFDC_SESSION, sessionId);
         } else {

--- a/src/test/java/com/springml/salesforce/wave/api/BulkAPITest.java
+++ b/src/test/java/com/springml/salesforce/wave/api/BulkAPITest.java
@@ -5,8 +5,11 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -126,6 +129,21 @@ public class BulkAPITest extends BaseAPITest {
         when(httpHelper.post(any(URI.class), anyString(), anyString(), anyBoolean())).thenReturn(CREATE_JOB_RESPONSE);
 
         JobInfo jobInfo = bulkAPI.createJob(STR_CONTACT);
+        assertEquals(STR_CONTACT, jobInfo.getObject());
+        assertNotNull(jobInfo.getId());
+        assertEquals(STR_JOB_ID, jobInfo.getId());
+    }
+
+    @Test
+    public void testCreateJobWithCustomHeaders() throws Exception {
+        Header customHeader = new BasicHeader("Sforce-Enable-PKChunking", "true");
+        List<Header> customHeaders = new ArrayList<Header>();
+        customHeaders.add(customHeader);
+
+        when(httpHelper.post(any(URI.class), anyString(), anyString(), anyBoolean(), eq(customHeaders))).thenReturn(CREATE_JOB_RESPONSE);
+
+        JobInfo inputJobInfo = new JobInfo(STR_CONTACT);
+        JobInfo jobInfo = bulkAPI.createJob(inputJobInfo, customHeaders);
         assertEquals(STR_CONTACT, jobInfo.getObject());
         assertNotNull(jobInfo.getId());
         assertEquals(STR_JOB_ID, jobInfo.getId());

--- a/src/test/java/com/springml/salesforce/wave/api/BulkAPITest.java
+++ b/src/test/java/com/springml/salesforce/wave/api/BulkAPITest.java
@@ -126,7 +126,7 @@ public class BulkAPITest extends BaseAPITest {
 
     @Test
     public void testCreateJob() throws Exception {
-        when(httpHelper.post(any(URI.class), anyString(), anyString(), anyBoolean())).thenReturn(CREATE_JOB_RESPONSE);
+        when(httpHelper.post(any(URI.class), anyString(), anyString(), anyBoolean(), anyList())).thenReturn(CREATE_JOB_RESPONSE);
 
         JobInfo jobInfo = bulkAPI.createJob(STR_CONTACT);
         assertEquals(STR_CONTACT, jobInfo.getObject());

--- a/src/test/java/com/springml/salesforce/wave/util/HTTPHelperTest.java
+++ b/src/test/java/com/springml/salesforce/wave/util/HTTPHelperTest.java
@@ -3,7 +3,13 @@ package com.springml.salesforce.wave.util;
 import static org.junit.Assert.*;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
+import org.apache.http.ParseException;
+import org.apache.http.message.BasicHeader;
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/springml/salesforce/wave/util/HTTPHelperTest.java
+++ b/src/test/java/com/springml/salesforce/wave/util/HTTPHelperTest.java
@@ -3,13 +3,7 @@ package com.springml.salesforce.wave.util;
 import static org.junit.Assert.*;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 
-import org.apache.http.Header;
-import org.apache.http.HeaderElement;
-import org.apache.http.ParseException;
-import org.apache.http.message.BasicHeader;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
Allow the user to customize the header to make the client more extensible. The following reference is an example of where a custom header would be valuable.
Reference: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_code_curl_walkthrough_pk_chunking.htm