### PR TITLE
Bug: BulkAPI isCompleted does not interpret all Batch States

### DIFF
--- a/src/main/java/com/springml/salesforce/wave/impl/BulkAPIImpl.java
+++ b/src/main/java/com/springml/salesforce/wave/impl/BulkAPIImpl.java
@@ -88,9 +88,11 @@ public class BulkAPIImpl extends AbstractAPIImpl implements BulkAPI {
         if (batchInfos != null) {
             for (BatchInfo batchInfo : batchInfos) {
                 LOG.debug("Batch state : " + batchInfo.getState());
-                isCompleted = STR_COMPLETED.equals(batchInfo.getState());
+                isCompleted = STR_COMPLETED.equals(batchInfo.getState()) || STR_NOT_PROCESSED.equals(batchInfo.getState());
                 if (STR_FAILED.equals(batchInfo.getState())) {
                     throw new Exception("Batch '" + batchInfo.getId() + "' failed with error '" + batchInfo.getStateMessage() + "'");
+                } else if (STR_IN_PROGRESS.equals(batchInfo.getState()) || STR_QUEUED.equals(batchInfo.getState())) {
+                    return false;
                 }
 
                 LOG.info("Number of records failed : " + batchInfo.getNumberRecordsFailed());

--- a/src/main/java/com/springml/salesforce/wave/util/WaveAPIConstants.java
+++ b/src/main/java/com/springml/salesforce/wave/util/WaveAPIConstants.java
@@ -17,6 +17,9 @@ public class WaveAPIConstants {
     public static final String STR_CLOSED = "Closed";
     public static final String STR_COMPLETED = "Completed";
     public static final String STR_FAILED = "Failed";
+    public static final String STR_QUEUED = "Queued";
+    public static final String STR_IN_PROGRESS = "InProgress";
+    public static final String STR_NOT_PROCESSED = "Not Processed";
 
     public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
     public static final String CONTENT_TYPE_APPLICATION_XML = "application/xml";

--- a/src/test/java/com/springml/salesforce/wave/api/BulkAPITest.java
+++ b/src/test/java/com/springml/salesforce/wave/api/BulkAPITest.java
@@ -155,6 +155,16 @@ public class BulkAPITest extends BaseAPITest {
     }
 
     @Test
+    public void testIsCompletedFalseCase() throws Exception {
+        final String GET_BATCHLIST_RESPONSE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><batchInfoList xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\"><batchInfo><id>751B0000000scSHIAY</id><jobId>750B0000000WlhtIAC</jobId><state>InProgress</state></batchInfo><batchInfo><id>751B0000000scSHIAZ</id><jobId>750B0000000WlhtIAC</jobId><state>Completed</state></batchInfo></batchInfoList>";
+        URI baseBatchURI = new URI(BASE_BATCH_URL);
+        when(httpHelper.get(baseBatchURI, SESSION_ID, true)).thenReturn(GET_BATCHLIST_RESPONSE);
+
+        assertFalse(bulkAPI.isCompleted(STR_JOB_ID));
+
+    }
+
+    @Test
     public void testGetBatchInfoList() throws Exception {
         BatchInfoList batchInfoList = bulkAPI.getBatchInfoList(STR_JOB_ID);
         assertNotNull(batchInfoList);


### PR DESCRIPTION
Reference: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_batches_interpret_status.htm

`BulkAPI#isCompleted` only considers the `Complete` and `Failed` state. It does not consider the other states (`Queued`, `InProgress`, `Not Processed`). 

This PR adds logic to interpret all the batch states.
